### PR TITLE
fix blocking issue when student's solution raise exceptions

### DIFF
--- a/xqueue_watcher/jailedgrader.py
+++ b/xqueue_watcher/jailedgrader.py
@@ -231,7 +231,12 @@ class JailedGrader(Grader):
                 if actual_outputs.stderr:
                     # The grader ran OK, but the student code didn't, so show the student
                     # details of what went wrong.  There is probably an exception to show.
-                    shown_error = actual_outputs.stderr or _('There was an error thrown while running your solution.')
+                    if isinstance(actual_outputs.stderr, bytes):
+                        shown_error = actual_outputs.stderr.decode('utf-8')
+                    elif isinstance(actual_outputs.stderr, str):
+                        shown_error = actual_outputs.stderr
+                    else:
+                        shown_error = 'There was an error thrown while running your solution.'
                     results['errors'].append(shown_error)
             else:
                 # The grader didn't run well, we are going to bail.


### PR DESCRIPTION
## Issue
The grader keeps reporting the following error message:
```2022-12-11 04:11:31,102 - xqueue_watcher.grader - ERROR - process_item
Traceback (most recent call last):
  File "/edx/app/xqueue_watcher/xqueue_watcher/grader.py", line 152, in process_item
    'msg': self.render_results(results)}
  File "/edx/app/xqueue_watcher/xqueue_watcher/grader.py", line 176, in render_results
    errors = format_errors(results['errors'])
  File "/edx/app/xqueue_watcher/xqueue_watcher/grader.py", line 18, in format_errors
    error_list = [esc(e) for e in errors or []]
  File "/edx/app/xqueue_watcher/xqueue_watcher/grader.py", line 18, in <listcomp>
    error_list = [esc(e) for e in errors or []]
  File "/usr/lib/python3.8/html/__init__.py", line 19, in escape
    s = s.replace("&", "&amp;") # Must be done first!
TypeError: a bytes-like object is required, not 'str'
```
And the other submissions get stuck.

## Root cause
1. Line 127 in jailedgrader.py, the err is a bytes object since the Popen is not in text mode.
2. Then in line 234, `shown_error` is that bytes object and appended to `results['errors']`
3. Line 152 in grader.py, when it tries to render the result, `format_errors(results['errors'])` sends the bytes to `html.escape` and raises this error.
4.  The submission is not yet graded because the grader doesn't send the result back. Therefore, it keeps pulling this submission and raising the same error.

## Fix
If the `actual_outputs.stderr` is `bytes`, decode it before appending it to `result['errors']`.

## Reproduce and test
1. Use `big_data_computing_grader/load_test/mock_xqueue.py` to create a mocked xqueue. The 
2. Run manager.py using a mock.json in `conf.d`, specifying "SERVER": "http://127.0.0.1:5000".
3. Before fix, the grader keeps rasing 
```
2022-12-15 15:29:17,856 INFO 16441 [xqueue_watcher.grader] jailedgrader.py:164 - Start grading submission from 12345, submission time: 54321.
2022-12-15 15:29:22,141 ERROR 16441 [xqueue_watcher.grader] grader.py:156 - process_item
Traceback (most recent call last):
  File "/Users/Maigo/work/big_data_computing_grader/xqueue_watcher/grader.py", line 152, in process_item
    'msg': self.render_results(results)}
  File "/Users/Maigo/work/big_data_computing_grader/xqueue_watcher/grader.py", line 176, in render_results
    errors = format_errors(results['errors'])
  File "/Users/Maigo/work/big_data_computing_grader/xqueue_watcher/grader.py", line 18, in format_errors
    error_list = [esc(e) for e in errors or []]
  File "/Users/Maigo/work/big_data_computing_grader/xqueue_watcher/grader.py", line 18, in <listcomp>
    error_list = [esc(e) for e in errors or []]
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/html/__init__.py", line 19, in escape
    s = s.replace("&", "&amp;") # Must be done first!
TypeError: a bytes-like object is required, not 'str'
```
4. After fix, the grader won't raise an error. And the mocked xqueue shows 
```
127.0.0.1 - - [15/Dec/2022 15:24:16] "GET /xqueue/get_submission/?queue_name=HKUSTx_BDT1 HTTP/1.1" 200 -
127.0.0.1 - - [15/Dec/2022 15:24:21] "POST /xqueue/put_result/ HTTP/1.1" 200 -
127.0.0.1 - - [15/Dec/2022 15:24:21] "GET /xqueue/get_submission/?queue_name=HKUSTx_BDT1 HTTP/1.1" 200 -
127.0.0.1 - - [15/Dec/2022 15:24:24] "POST /xqueue/put_result/ HTTP/1.1" 200 -
127.0.0.1 - - [15/Dec/2022 15:24:24] "GET /xqueue/get_submission/?queue_name=HKUSTx_BDT1 HTTP/1.1" 200 -
127.0.0.1 - - [15/Dec/2022 15:24:27] "POST /xqueue/put_result/ HTTP/1.1" 200 -
```